### PR TITLE
Add start menu shortcut in the correct spot

### DIFF
--- a/FlashpointInstaller/src/Forms/Operate.cs
+++ b/FlashpointInstaller/src/Forms/Operate.cs
@@ -252,7 +252,14 @@ namespace FlashpointInstaller
                 }
                 if (FPM.Main.ShortcutStartMenu.Checked)
                 {
-                    shortcutPaths.Add(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu));
+                    if (Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Programs)))
+                    {
+                        shortcutPaths.Add(Environment.GetFolderPath(Environment.SpecialFolder.Programs));
+                    }
+                    else
+                    {
+                        shortcutPaths.Add(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu));
+                    }
                 }
 
                 foreach (string path in shortcutPaths)


### PR DESCRIPTION
I had to fix this because usually, right now, Flashpoint installs its start menu shortcut in the wrong folder:

![File Explorer window showing red arrow pointing from Flashpoint shortcut to Programs folder in the Start Menu folder](https://github.com/FlashpointProject/FlashpointComponentTools/assets/39467046/b1c18028-6a65-425e-935f-d55312e1e502)

Usually, all programs install itself in the correct folder: `<StartMenuPath>\Programs` instead of just the Start Menu folder. This pull request aims to fix that issue by checking if the Programs folder exists, and if it does, install it from there. If not, create it from just the Start Menu folder.